### PR TITLE
Bump memory size

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -128,7 +128,7 @@ include user/Makefrag
 
 GDBPORT 	= 26000
 QEMUGDB 	= -gdb tcp::$(GDBPORT)
-QEMUOPTS 	= -drive file=$(IMAGE),media=disk,format=raw -smp 2 -m 32 $(QEMUEXTRAS)
+QEMUOPTS 	= -drive file=$(IMAGE),media=disk,format=raw -smp 2 -m 256 $(QEMUEXTRAS)
 
 qemu: all
 	$(V)$(QEMU) -serial mon:stdio $(QEMUOPTS)


### PR DESCRIPTION
The current memory size breaks some functions as the kernel panics with no enough memory. Also, the size is set to 256M in the Windows build.